### PR TITLE
Implement stack based assignment using let keyword

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -114,6 +114,11 @@ class ImperivmExecutor:
         result = self.resolve_value(value, bindings)
         bindings.assign(target, result)
 
+    def instruction_let(self, args, bindings):
+        [(_, target)] = args
+        value = self.stack.pop()
+        bindings.assign(target, value)
+
     def instruction_invocation(self, args):
         _, subroutine = args[0]
         self.invoke_subroutine(subroutine, Bindings())
@@ -181,6 +186,8 @@ class ImperivmExecutor:
             self.instruction_pop(args, bindings)
         elif operation == "assign":
             self.instruction_assign(args, bindings)
+        elif operation == "let":
+            self.instruction_let(args, bindings)
         elif operation == "invocation":
             self.instruction_invocation(args)
         elif operation == "stop":

--- a/grammar.py
+++ b/grammar.py
@@ -5,9 +5,11 @@ imperivm = Grammar(
     program         = subroutine (sp_0n br ws_0n subroutine)* ws_0n
     subroutine      = identifier ws_1n block
     block           = begin ws_1n (instruction (sp_0n br ws_0n instruction)*)? ws_1n end
-    instruction     = assignment / conditional / loop / stack_op / arithmetic_op / boolean_op / io_op / stop / identifier / halt / store / load
+    instruction     = assignment / conditional / loop / stack_op
+                        / arithmetic_op / boolean_op / io_op / stop / identifier
+                        / halt / store / load
 
-    assignment      = assign sp_1n value sp_1n identifier
+    assignment      = (assign sp_1n value sp_1n identifier) / (let sp_1n identifier)
     conditional     = if sp_1n value ws_1n block (ws_1n elif sp_1n value ws_1n block)* (ws_1n else ws_1n block)?
     loop            = while sp_1n value ws_1n block
     stack_op        = (push sp_1n value) / (pop sp_1n identifier)
@@ -35,8 +37,9 @@ imperivm = Grammar(
     sp_1n           = ~r"[ \t]+"
 
     reserved        = begin / end / stop / if / elif / else / while / push
-                        / pop / assign / add / subtract / multiply / divide
-                        / and / or / xor / not / print / exit / store / load
+                        / pop / assign / let / add / subtract / multiply
+                        / divide / and / or / xor / not / print / exit / store
+                        / load
     begin           = ~r"begin"i / ~r"do"i
     exit            = ~r"exit"i
     end             = ~r"end"i
@@ -48,15 +51,16 @@ imperivm = Grammar(
     push            = ~r"push"i
     pop             = ~r"pop"i
     assign          = ~r"assign"i
+    let             = ~r"let"i
     add             = ~r"add"i
     subtract        = ~r"subtract"i
     multiply        = ~r"multiply"i
     divide          = ~r"divide"i
     and             = ~r"and"i
     or              = ~r"or"i
-    xor             = ~"xor"i
+    xor             = ~r"xor"i
     negate          = ~r"negate"i
-    not             = ~"not"i
+    not             = ~r"not"i
     print           = ~r"print"i
     store           = ~r"store"i
     load            = ~r"load"i

--- a/tests/and.imp
+++ b/tests/and.imp
@@ -1,5 +1,6 @@
 main begin
-  assign 1 x
+  push 1
+  let x
   push 2
   and x
   

--- a/visitor.py
+++ b/visitor.py
@@ -34,8 +34,15 @@ class ImperivmVisitor(NodeVisitor):
         return visited_children
 
     def visit_assignment(self, _, visited_children):
-        instruction, _, value, _, target = visited_children
-        return instruction.text, value, target
+        [instruction, *_] = visited_children[0]
+        if instruction.text == "assign":
+            _, _, value, _, target = visited_children[0]
+            return instruction.text, value, target
+        elif instruction.text == "let":
+            _, _, target = visited_children[0]
+            return instruction.text, target
+        else:
+            raise Exception(f"Unknown assignment {instruction}")
 
     def visit_conditional(self, _, visited_children):
         operation, _, condition, _, block, elif_operations, else_operations = (

--- a/visitor.py
+++ b/visitor.py
@@ -42,7 +42,7 @@ class ImperivmVisitor(NodeVisitor):
             _, _, target = visited_children[0]
             return instruction.text, target
         else:
-            raise Exception(f"Unknown assignment {instruction}")
+            raise ValueError(f"Unknown assignment {instruction}")
 
     def visit_conditional(self, _, visited_children):
         operation, _, condition, _, block, elif_operations, else_operations = (


### PR DESCRIPTION
We add a new `let`keyword to replace `assign`. `let` uses the last value on the queue instead of receiving a parameter.