### PR TITLE
Remove old `assign` keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Imperivm is a simple, stack-based programming language with a focus on clarity a
 - **Stack Operations**: Push and pop values to/from the stack.
 - **Control Flow**: Conditional branching (`if`, `elif`, `else`) and loops (`while`).
 - **Arithmetic Operations**: Basic operations like addition, subtraction, multiplication, and division.
-- **Variables**: Assign and use named variables.
+- **Variables**: Assign and use named variables (`let`).
 - **Input/Output**: Print strings or variable values.
 - **Modularity**: Define subroutines for reusable code.
 
@@ -39,7 +39,8 @@ Instructions include variable assignment, stack operations, arithmetic operation
 #### Variable Assignment
 Assign a value to a variable:
 ```imperivm
-assign 42 x
+push 42
+let x
 ```
 
 #### Stack Operations

--- a/executor.py
+++ b/executor.py
@@ -109,11 +109,6 @@ class ImperivmExecutor:
         value = self.stack.pop()
         bindings.assign(target, value)
 
-    def instruction_assign(self, args, bindings):
-        value, (_, target) = args
-        result = self.resolve_value(value, bindings)
-        bindings.assign(target, result)
-
     def instruction_let(self, args, bindings):
         [(_, target)] = args
         value = self.stack.pop()
@@ -184,8 +179,6 @@ class ImperivmExecutor:
             self.instruction_push(args, bindings)
         elif operation == "pop":
             self.instruction_pop(args, bindings)
-        elif operation == "assign":
-            self.instruction_assign(args, bindings)
         elif operation == "let":
             self.instruction_let(args, bindings)
         elif operation == "invocation":

--- a/grammar.py
+++ b/grammar.py
@@ -9,7 +9,7 @@ imperivm = Grammar(
                         / arithmetic_op / boolean_op / io_op / stop / identifier
                         / halt / store / load
 
-    assignment      = (assign sp_1n value sp_1n identifier) / (let sp_1n identifier)
+    assignment      = let sp_1n identifier
     conditional     = if sp_1n value ws_1n block (ws_1n elif sp_1n value ws_1n block)* (ws_1n else ws_1n block)?
     loop            = while sp_1n value ws_1n block
     stack_op        = (push sp_1n value) / (pop sp_1n identifier)
@@ -37,7 +37,7 @@ imperivm = Grammar(
     sp_1n           = ~r"[ \t]+"
 
     reserved        = begin / end / stop / if / elif / else / while / push
-                        / pop / assign / let / add / subtract / multiply
+                        / pop / let / add / subtract / multiply
                         / divide / and / or / xor / not / print / exit / store
                         / load
     begin           = ~r"begin"i / ~r"do"i
@@ -50,7 +50,6 @@ imperivm = Grammar(
     while           = ~r"while"i
     push            = ~r"push"i
     pop             = ~r"pop"i
-    assign          = ~r"assign"i
     let             = ~r"let"i
     add             = ~r"add"i
     subtract        = ~r"subtract"i

--- a/tests/add.imp
+++ b/tests/add.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign -5 x
+        push -5
+        let x
         add 5 x
         exit x
         exit 1

--- a/tests/assign.imp
+++ b/tests/assign.imp
@@ -1,6 +1,0 @@
-main
-    begin
-        assign 0 x
-        exit x
-        exit 1
-    end

--- a/tests/divide.imp
+++ b/tests/divide.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign 0 x
+        push 0
+        let x
         divide 14884 x
         exit x
         exit 1

--- a/tests/if.imp
+++ b/tests/if.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign 1 x
+        push 1
+        let x
         if x
             begin
                 exit 0

--- a/tests/if_elif.imp
+++ b/tests/if_elif.imp
@@ -1,7 +1,9 @@
 main
     begin
-        assign 0 x
-        assign 1 y
+        push 0
+        let x
+        push 1
+        let y
         if x
             begin
                 exit 1

--- a/tests/if_elif_else.imp
+++ b/tests/if_elif_else.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign 0 x
+        push 0
+        let x
         if x
             begin
                 exit 1

--- a/tests/if_else.imp
+++ b/tests/if_else.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign 0 x
+        push 0
+        let x
         if x
             begin
                 exit 1

--- a/tests/multiply.imp
+++ b/tests/multiply.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign 84781 x
+        push 84781
+        let x
         multiply 0 x
         exit x
         exit 1

--- a/tests/negate.imp
+++ b/tests/negate.imp
@@ -1,5 +1,6 @@
 main begin
-  assign 1 x
+  push 1
+  let x
   negate x
 
   add 2 x

--- a/tests/not.imp
+++ b/tests/not.imp
@@ -1,5 +1,6 @@
 main begin
-  assign 1 x
+  push 1
+  let x
   not x
   
   if x do

--- a/tests/or.imp
+++ b/tests/or.imp
@@ -1,5 +1,6 @@
 main begin
-  assign 1 x
+  push 1
+  let x
   push 2
   or x
 

--- a/tests/subtract.imp
+++ b/tests/subtract.imp
@@ -1,6 +1,7 @@
 main
     begin
-        assign 5 x
+        push 5
+        let x
         subtract 5 x
         exit x
         exit 1

--- a/tests/xor.imp
+++ b/tests/xor.imp
@@ -1,5 +1,6 @@
 main begin
-  assign 1 x
+  push 1
+  let x
   push 3
   xor x
 

--- a/visitor.py
+++ b/visitor.py
@@ -34,15 +34,8 @@ class ImperivmVisitor(NodeVisitor):
         return visited_children
 
     def visit_assignment(self, _, visited_children):
-        [instruction, *_] = visited_children[0]
-        if instruction.text == "assign":
-            _, _, value, _, target = visited_children[0]
-            return instruction.text, value, target
-        elif instruction.text == "let":
-            _, _, target = visited_children[0]
-            return instruction.text, target
-        else:
-            raise ValueError(f"Unknown assignment {instruction}")
+        instruction, _, target = visited_children
+        return instruction.text, target
 
     def visit_conditional(self, _, visited_children):
         operation, _, condition, _, block, elif_operations, else_operations = (


### PR DESCRIPTION
The new `let` keyword introduced in #9 allows stack-based assignments. This is more in consonance with the direction we want for imperivm'o design so the old `assign` keyword should be removed.