### PR TITLE
Fix logical not returning wrong result

### DIFF
--- a/src/executor.py
+++ b/src/executor.py
@@ -112,7 +112,7 @@ class ImperivmExecutor:
     def instruction_not(self, args, bindings):
         ((_, target),) = args
         old = bindings.resolve(target)
-        bindings.assign(target, 0 if old else old)
+        bindings.assign(target, 0 if old else 1)
 
     def instruction_if(self, args, bindings):
         for index in range(0, len(args) - 1, 2):

--- a/tests/not.imp
+++ b/tests/not.imp
@@ -6,4 +6,14 @@ main begin
   if x do
     exit 1
   end
+
+  push 0
+  pop x
+  not x
+
+  if x do
+    exit 0
+  end
+
+  exit 1
 end


### PR DESCRIPTION
Logical `not` instruction returned 0 if the value was non-zero and the same value otherwise, meaning it always returned 0. We make it return 1 in the second case, so it works as one would expect.