### PR TITLE
Add `Ast` class

### DIFF
--- a/src/executor.py
+++ b/src/executor.py
@@ -1,6 +1,7 @@
 import inspect
 
 from bindings import Bindings
+from parser import Ast
 
 
 class UnknownSubroutine(Exception):
@@ -12,7 +13,7 @@ class InvalidMemoryAddressException(Exception):
 
 
 class ImperivmExecutor:
-    def __init__(self, ast):
+    def __init__(self, ast: Ast):
         self.subroutines = {}
         self.stack = []
         self.heap = []

--- a/src/parser.py
+++ b/src/parser.py
@@ -29,7 +29,7 @@ class ImperivmParser:
         self.visitor = visitor
         self.preprocessor = preprocessor
 
-    def parse(self, program):
+    def parse(self, program: str):
         program = self.preprocessor.process(program)
         tree = self.grammar.parse(program)
         return Ast(self.visitor.visit(tree))

--- a/src/parser.py
+++ b/src/parser.py
@@ -7,6 +7,17 @@ import visitor
 import preprocessor
 
 
+class Ast:
+    def __init__(self, tree: tuple):
+        self.tree = tree
+
+    def __iter__(self):
+        return self.tree.__iter__()
+
+    def __repr__(self):
+        return self.tree.__repr__()
+
+
 class ImperivmParser:
     def __init__(
         self,
@@ -21,7 +32,7 @@ class ImperivmParser:
     def parse(self, program):
         program = self.preprocessor.process(program)
         tree = self.grammar.parse(program)
-        return self.visitor.visit(tree)
+        return Ast(self.visitor.visit(tree))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We refactor the AST produced by the parser to a new class that's compatible with the existing code but will allow us to extend the AST with new behaviours in the future without compromising the existing interface. The original tuple-based tree can still be accessed via `Ast#tree` method.

This class also provides extra name-based type safety under a convenient name.